### PR TITLE
Bootloader migration away from syslinux (#527)

### DIFF
--- a/manifest
+++ b/manifest
@@ -200,7 +200,6 @@ export USER_SERVICES="\
 
 export FILES_TO_DELETE="\
 	/boot/initramfs-linux-fallback.img \
-	/boot/syslinux \
 	/usr/share/SFML \
 	/usr/share/doc \
 	/usr/share/gtk-doc \

--- a/rootfs/usr/lib/frzr.d/require_reboot.migration
+++ b/rootfs/usr/lib/frzr.d/require_reboot.migration
@@ -1,5 +1,4 @@
-# Require reboot
+# triggers notification for reboot in old BPM
 post_install() {
-  echo "Set up /var/run/reboot-required"
   touch /var/run/reboot-required
 }

--- a/rootfs/usr/lib/frzr.d/systemd-boot.migration
+++ b/rootfs/usr/lib/frzr.d/systemd-boot.migration
@@ -1,0 +1,63 @@
+# Migrate to systemd-boot
+post_install() {
+	local MOUNT_PATH=$1
+	local SUBVOL=$2
+	local NAME=$3
+
+	local BOOT_CFG="${MOUNT_PATH}/boot/loader/entries/frzr.conf"
+	local AMD_UCODE=""
+	local INTEL_UCODE=""
+	local ADDITIONAL_ARGUMENTS=""
+
+	if [ -e ${BOOT_CFG} ]; then
+		# migration has already completed, exit silently
+		return 0
+	fi
+
+	echo "Migrating to systemd-boot..."
+
+	if [ "$#" -lt 3 ]; then
+		echo "Migration aborted: not enough arguments"
+		return 1
+	fi
+
+	if [ ! -d /sys/firmware/efi/efivars ]; then
+		echo "Aborting: cannot migrate legacy BIOS install to systemd-boot"
+		return 0
+	fi
+
+	rm -rf ${MOUNT_PATH}/boot/EFI
+	bootctl --esp-path=${MOUNT_PATH}/boot/ install
+
+	if [ -e ${MOUNT_PATH}/boot/${NAME}/amd-ucode.img ] ; then
+		AMD_UCODE="initrd /${NAME}/amd-ucode.img"
+	fi
+
+	if [ -e ${MOUNT_PATH}/boot/${NAME}/intel-ucode.img ] ; then
+		INTEL_UCODE="initrd /${NAME}/intel-ucode.img"
+	fi
+
+	if [ -e ${SUBVOL}/usr/lib/frzr.d/bootconfig.conf ] ; then
+		ADDITIONAL_ARGUMENTS="$ADDITIONAL_ARGUMENTS $(cat ${SUBVOL}/usr/lib/frzr.d/bootconfig.conf)"
+	fi
+
+	echo "default frzr.conf" > ${MOUNT_PATH}/boot/loader/loader.conf
+	get_boot_cfg "${NAME}" "${AMD_UCODE}" "${INTEL_UCODE}" "${ADDTIONAL_ARGUMENTS}" > ${BOOT_CFG}
+
+	echo "Migration to systemd-boot complete"
+}
+
+
+get_boot_cfg() {
+	local version=${1}
+	local amd_ucode=${2}
+	local intel_ucode=${3}
+	local additional_arguments=${4}
+
+echo "title ${version}
+linux /${version}/vmlinuz-linux
+${amd_ucode}
+${intel_ucode}
+initrd /${version}/initramfs-linux.img
+options root=LABEL=frzr_root rw rootflags=subvol=deployments/${version} quiet splash loglevel=3 rd.systemd.show_status=auto rd.udev.log_priority=3 ${additional_arguments}"
+}


### PR DESCRIPTION
* Migrate old post-update into migrations system

* WIP: simplest version of systemd-boot install

* Adjust the migration draft to be functional for testing

* don't want this to be constantly showing messages

* fully implement migration to systemd-boot (untested)

* no more syslinux, don't need this

* prevent running systemd migration with incompatible frzr

* fix whitespace

---------